### PR TITLE
perf: improving compilation time

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "yarn lint && yarn mocha",
     "mocha": "_mocha --opts src/test/mocha.opts",
     "cover": "nyc --reporter=lcov --reporter=text-summary npm run mocha",
-    "lint": "tslint -c tslint.json \"src/**/*.ts\" \"test/**/*.ts\""
+    "lint": "tslint -c tslint.json \"src/**/*.ts\" \"test/**/*.ts\"",
+    "benchmark": "tsc --extendedDiagnostics --incremental false"
   },
   "repository": {
     "type": "git",

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -1,6 +1,8 @@
 'use strict';
 
-import {SQS, S3, AWSError} from 'aws-sdk';
+import * as SQS from 'aws-sdk/clients/sqs'
+import * as S3 from 'aws-sdk/clients/s3'
+import {AWSError} from 'aws-sdk/lib/error'
 import {BodyFormat, Squiss} from '.';
 import {IMessageAttributes, parseMessageAttributes} from './attributeUtils';
 import {EventEmitter} from 'events';

--- a/src/Squiss.ts
+++ b/src/Squiss.ts
@@ -7,7 +7,8 @@ import {Message} from './Message';
 import {ITimeoutExtenderOptions, TimeoutExtender} from './TimeoutExtender';
 import {createMessageAttributes, IMessageAttributes} from './attributeUtils';
 import {isString} from 'ts-type-guards';
-import {SQS, S3} from 'aws-sdk';
+import * as SQS from 'aws-sdk/clients/sqs'
+import * as S3 from 'aws-sdk/clients/s3'
 import {GZIP_MARKER, compressMessage} from './gzipUtils';
 import {S3_MARKER, uploadBlob} from './s3Utils';
 import {getMessageSize} from './messageSizeUtils';

--- a/src/Squiss.ts
+++ b/src/Squiss.ts
@@ -1,6 +1,5 @@
 'use strict';
 
-import * as AWS from 'aws-sdk';
 import * as url from 'url';
 import {EventEmitter} from 'events';
 import {Message} from './Message';
@@ -12,7 +11,8 @@ import * as S3 from 'aws-sdk/clients/s3'
 import {GZIP_MARKER, compressMessage} from './gzipUtils';
 import {S3_MARKER, uploadBlob} from './s3Utils';
 import {getMessageSize} from './messageSizeUtils';
-import {AWSError} from 'aws-sdk';
+import {AWSError} from 'aws-sdk/lib/error'
+import {Request} from 'aws-sdk/lib/request'
 import {
     IMessageToSend, ISendMessageRequest,
     IDeleteQueueItem, IDeleteQueueItemById, optDefaults, SquissEmitter, ISquissOptions
@@ -43,7 +43,7 @@ export class Squiss extends (EventEmitter as new() => SquissEmitter) {
     private _queueUrl: string;
     private _delQueue = new Map<string, IDeleteQueueItem>();
     private _delTimer: any;
-    private _activeReq: AWS.Request<SQS.Types.ReceiveMessageResult, AWS.AWSError> | undefined;
+    private _activeReq: Request<SQS.Types.ReceiveMessageResult, AWSError> | undefined;
 
     constructor(opts?: ISquissOptions | undefined) {
         super();

--- a/src/TimeoutExtender.ts
+++ b/src/TimeoutExtender.ts
@@ -4,7 +4,7 @@ import {Squiss} from './index';
 import {Message} from './Message';
 import * as LinkedList from 'linked-list';
 import {Item} from 'linked-list';
-import {AWSError} from 'aws-sdk';
+import {AWSError} from 'aws-sdk/lib/error';
 
 const MAX_MESSAGE_AGE_MS = 43200000;
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1,7 +1,9 @@
 'use strict';
 
 import {Message} from './Message';
-import {AWSError, SQS, S3} from 'aws-sdk';
+import * as SQS from 'aws-sdk/clients/sqs'
+import * as S3 from 'aws-sdk/clients/s3'
+import {AWSError} from 'aws-sdk/lib/error'
 import {BatchResultErrorEntry} from 'aws-sdk/clients/sqs';
 import {IS3Upload} from './s3Utils';
 import {StrictEventEmitter} from './EventEmitterTypesHelper';

--- a/src/attributeUtils.ts
+++ b/src/attributeUtils.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import {SQS} from 'aws-sdk';
+import * as SQS from 'aws-sdk/clients/sqs'
 import {isBoolean, isNumber, isString} from 'ts-type-guards';
 
 const EMPTY_OBJ = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 'use strict';
 
 /* istanbul ignore file */
-export {SQS, S3} from 'aws-sdk';
+import * as SQS from 'aws-sdk/clients/sqs'
+export {SQS}
+import * as S3 from 'aws-sdk/clients/s3'
+export {S3}
+// export {SQS, S3} from 'aws-sdk';
 export {Squiss} from './Squiss';
 export {
     BodyFormat,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import * as SQS from 'aws-sdk/clients/sqs'
 export {SQS}
 import * as S3 from 'aws-sdk/clients/s3'
 export {S3}
-// export {SQS, S3} from 'aws-sdk';
 export {Squiss} from './Squiss';
 export {
     BodyFormat,

--- a/src/messageSizeUtils.ts
+++ b/src/messageSizeUtils.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import {ISendMessageRequest} from './index';
-import {SQS} from 'aws-sdk';
+import * as SQS from 'aws-sdk/clients/sqs';
 
 export const getMessageSize = (message: ISendMessageRequest): number => {
     const msgAttributesSize = getMsgAttributesSize(message.MessageAttributes);

--- a/src/s3Utils.ts
+++ b/src/s3Utils.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import {S3} from 'aws-sdk';
+import * as S3 from 'aws-sdk/clients/s3';
 import { v4 as uuidv4 } from 'uuid';
 import {getSizeInBytes} from './messageSizeUtils';
 

--- a/src/test/src/TimeoutExtender.spec.ts
+++ b/src/test/src/TimeoutExtender.spec.ts
@@ -7,7 +7,7 @@ import delay from 'delay';
 // @ts-ignore
 import * as sinon from 'sinon';
 import {S3Stub} from '../stubs/S3Stub';
-import {S3} from 'aws-sdk';
+import * as S3 from 'aws-sdk/clients/s3';
 
 const getSquissStub = () => {
   return new SquissStub() as any as Squiss;

--- a/src/test/src/index.spec.ts
+++ b/src/test/src/index.spec.ts
@@ -14,7 +14,6 @@ const stubs = {
 // tslint:disable-next-line
 const {Squiss: SquissPatched, Message: MessagePatched} = proxyquire('../../', stubs);
 
-import * as AWS from 'aws-sdk';
 import {ISquissOptions, Squiss} from '../../';
 import {SQSStub} from '../stubs/SQSStub';
 import delay from 'delay';
@@ -23,13 +22,13 @@ import {IMessageOpts } from '../../Message';
 // @ts-ignore
 import * as sinon from 'sinon';
 import * as chai from 'chai';
-import {SQS, S3} from 'aws-sdk';
+import * as SQS from 'aws-sdk/clients/sqs'
+import * as S3 from 'aws-sdk/clients/s3'
 import {EventEmitter} from 'events';
 import {Blobs, S3Stub} from '../stubs/S3Stub';
 
 const should = chai.should();
 let inst: Squiss | null = null;
-const origSQS = AWS.SQS;
 const wait = (ms?: number) => delay(ms === undefined ? 20 : ms);
 
 const getS3Stub = (blobs?: Blobs) => {
@@ -50,8 +49,6 @@ describe('index', () => {
       inst!.stop();
     }
     inst = null;
-    // @ts-ignore
-    AWS.SQS = origSQS;
   });
   describe('constructor', () => {
     it('creates a new SquissPatched instance', () => {

--- a/src/test/stubs/S3Stub.ts
+++ b/src/test/stubs/S3Stub.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import {EventEmitter} from 'events';
-import {S3} from 'aws-sdk';
+import * as S3 from 'aws-sdk/clients/s3';
 
 export interface Blobs {
   [k: string]: { [k: string]: string };

--- a/src/test/stubs/SQSStub.ts
+++ b/src/test/stubs/SQSStub.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import {EventEmitter} from 'events';
-import {SQS} from 'aws-sdk';
+import * as SQS from 'aws-sdk/clients/sqs';
 
 export class SQSStub extends EventEmitter {
 


### PR DESCRIPTION
<!-- A similar PR may already be submitted!
Please search among the [Pull request](../) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.

-->
**Summary**

This PR fixes/implements the following **bugs/features**

* [x] Improves typescript compilation time #119 

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Compilation time of the library can be decreased by importing aws services directly from their client files instead of the entire SDK. This also reduces the compilation time of projects that use `squiss-ts` as a dependency.

**Test plan (required)**

It is not that easy to measure and compare typescript compilation performance in a CI environment. Only added a npm script `benchmark` that uses `tsc`'s `--extendedDiagnostics` flag, the advice would be to run this before a merge to notice any regression in compilation performance.
