### PR TITLE
bind `_drainDeleteQueue` to `this`

### DIFF
--- a/src/Squiss.ts
+++ b/src/Squiss.ts
@@ -62,6 +62,7 @@ export class Squiss extends (EventEmitter as new() => SquissEmitter) {
         this._initOpts();
         this._queueUrl = this._opts.queueUrl || '';
         this.sqs = this._initSqs();
+        this._drainDeleteQueue = this._drainDeleteQueue.bind(this);
     }
 
     public changeMessageVisibility(msg: Message | string, timeoutInSeconds: number): Promise<void> {


### PR DESCRIPTION
<!-- A similar PR may already be submitted!
Please search among the [Pull request](../) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.

-->
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] Bug https://github.com/PruvoNet/squiss-ts/issues/201

<!-- You can skip this if you're fixing a typo or alike -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

it seems that in some edge-case, 
`_drainDeleteQueue` loses the `this` context.

by binding it forcefully, it shouldn't happen
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**
unfortunately, since i don't have steps to reproduce,
i do not have a clear plan of testing this.

the plan i have, is referencing the fork in my code,
and to update whether it stops happening 
<!-- Make sure tests pass on both Travis and locally. -->
